### PR TITLE
썸네일 접근 경로 권한 설정, 파일 업로드 용량 제한 변경

### DIFF
--- a/src/main/java/live/narcy/weather/city/service/CityService.java
+++ b/src/main/java/live/narcy/weather/city/service/CityService.java
@@ -87,7 +87,7 @@ public class CityService {
                     .name(param.get("cityName"))
                     .korName(param.get("cityKorName"))
                     .country(param.get("country"))
-                    .thumbnail(THUMBNAIL_PATH + param.get("cityName") + ".png")
+                    .thumbnail("/thumbnail/" + param.get("cityName") + ".png")
                     .delYn("n")
                     .build();
 
@@ -126,7 +126,7 @@ public class CityService {
                     .country(param.get("country"))
                     .name(param.get("cityName"))
                     .korName(param.get("cityKorName"))
-                    .thumbnail(THUMBNAIL_PATH + param.get("cityName") + ".png")
+                    .thumbnail("/thumbnail/" + param.get("cityName") + ".png")
                     .delYn(param.get("delYn"))
                     .build();
 

--- a/src/main/java/live/narcy/weather/config/SecurityConfig.java
+++ b/src/main/java/live/narcy/weather/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
         // 접근 권한 설정
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/home", "/login/**", "/join", "/joinProc", "/oauth2/**").permitAll()
+                        .requestMatchers("/", "/home", "/login/**", "/join", "/joinProc", "/oauth2/**", "/thumbnail/**").permitAll()
                         .requestMatchers("/api/admin/**", "/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 );

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,8 +17,8 @@ spring.jpa.properties.hibernate.format_sql=true
 server.servlet.session.timeout=30m
 
 # \uD30C\uC77C \uC5C5\uB85C\uB4DC \uC6A9\uB7C9 \uC81C\uD55C
-spring.servlet.multipart.max-file-size=10MB
-spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB
 
 # \uD3EC\uD2B8 \uC124\uC815
 #server.port=80


### PR DESCRIPTION
1. 썸네일 이미지 접근 경로 권한 설정(permitAll)
2. 파일 업로드 용량 제한 변경 (10MB -> 5MB)