### PR TITLE
로깅 설정(타임존, 요청IP), OAuth2 사용자 이름 제거

### DIFF
--- a/src/main/java/live/narcy/weather/NarcyApplication.java
+++ b/src/main/java/live/narcy/weather/NarcyApplication.java
@@ -3,10 +3,14 @@ package live.narcy.weather;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class NarcyApplication {
 
     public static void main(String[] args) {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));    // 타임존 설정
+
         SpringApplication.run(NarcyApplication.class, args);
     }
 

--- a/src/main/java/live/narcy/weather/config/LoggingInterceptor.java
+++ b/src/main/java/live/narcy/weather/config/LoggingInterceptor.java
@@ -26,8 +26,18 @@ public class LoggingInterceptor implements HandlerInterceptor {
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
         long startTime = (Long) request.getAttribute(START_TIME);
         long duration = System.currentTimeMillis() - startTime;
-        String XRI = request.getHeader("X-Real-IP");
-        String XFF = request.getHeader("X-Forwarded-For");
+
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null) {
+            ip = request.getHeader("X-Real-IP");
+        }
+        if (ip == null) {
+            ip = request.getRemoteAddr();
+        }
+        // X-Forwarded-For가 여러 IP면, 맨 앞 IP만 사용
+        if (ip != null && ip.contains(",")) {
+            ip = ip.split(",")[0].trim();
+        }
 
         String email = "anonymous";
         Authentication authentication = (Authentication) request.getUserPrincipal();
@@ -35,7 +45,6 @@ public class LoggingInterceptor implements HandlerInterceptor {
             email = ((CustomOAuth2User) authentication.getPrincipal()).getEmail();
         }
 
-        String ip = request.getRemoteAddr();
         String method = request.getMethod();
         String uri = request.getRequestURI();
         int status = response.getStatus();

--- a/src/main/java/live/narcy/weather/config/WebConfig.java
+++ b/src/main/java/live/narcy/weather/config/WebConfig.java
@@ -35,11 +35,12 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loggingInterceptor)
-                .addPathPatterns("/**") // 모든 요청에 적용
-                .excludePathPatterns("/assets/**")
+                .addPathPatterns("/**")             // 모든 요청에 적용
+                .excludePathPatterns("/assets/**")  // 제외할 요청들
                 .excludePathPatterns("/vendors/**")
                 .excludePathPatterns("/js/**")
                 .excludePathPatterns("/error/**")
+                .excludePathPatterns("/thumbnail/**")
                 .excludePathPatterns("/cctvLogin.html");
     }
 }

--- a/src/main/java/live/narcy/weather/member/dto/CustomOAuth2User.java
+++ b/src/main/java/live/narcy/weather/member/dto/CustomOAuth2User.java
@@ -40,7 +40,7 @@ public class CustomOAuth2User implements OAuth2User {
     @Override
     public String getName() {
 
-        return oAuth2Response.getName();
+        return oAuth2Response.getEmail();
     }
 
     // 사용자 식별정보(ID)

--- a/src/main/java/live/narcy/weather/member/dto/KakaoResponse.java
+++ b/src/main/java/live/narcy/weather/member/dto/KakaoResponse.java
@@ -26,9 +26,9 @@ public class KakaoResponse implements OAuth2Response{
         return kakao_account.get("email").toString();
     }
 
-    @Override
-    public String getName() {
-        Map<String, Object> properties =  (Map<String, Object>)attribute.get("properties");
-        return properties.get("nickname").toString();
-    }
+//    @Override
+//    public String getName() {
+//        Map<String, Object> properties =  (Map<String, Object>)attribute.get("properties");
+//        return properties.get("nickname").toString();
+//    }
 }

--- a/src/main/java/live/narcy/weather/member/dto/NaverResponse.java
+++ b/src/main/java/live/narcy/weather/member/dto/NaverResponse.java
@@ -25,8 +25,8 @@ public class NaverResponse implements OAuth2Response{
         return attribute.get("email").toString();
     }
 
-    @Override
-    public String getName() {
-        return attribute.get("name").toString();
-    }
+//    @Override
+//    public String getName() {
+//        return attribute.get("name").toString();
+//    }
 }

--- a/src/main/java/live/narcy/weather/member/dto/OAuth2Response.java
+++ b/src/main/java/live/narcy/weather/member/dto/OAuth2Response.java
@@ -12,5 +12,5 @@ public interface OAuth2Response {
     String getEmail();
 
     // 사용자 이름
-    String getName();
+//    String getName();
 }


### PR DESCRIPTION
1. 로그 기록 타임존 수정(UTC -> KST)
2. 로그 기록 시 요청한 클라이언트 IP 가져오기
3. OAuth2 네이버 로그인 검수를 위해 불필요한 사용자 이름 제거