### PR TITLE
조회 정보 등록 로직 변경(with Redis)

### DIFF
--- a/src/main/java/live/narcy/weather/NarcyApplication.java
+++ b/src/main/java/live/narcy/weather/NarcyApplication.java
@@ -3,6 +3,7 @@ package live.narcy.weather;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 import javax.xml.stream.events.Namespace;
@@ -11,6 +12,7 @@ import java.util.TimeZone;
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableRedisHttpSession(redisNamespace = "${spring.session.redis.namespace}")
+@EnableScheduling
 public class NarcyApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/live/narcy/weather/city/controller/CityController.java
+++ b/src/main/java/live/narcy/weather/city/controller/CityController.java
@@ -1,5 +1,6 @@
 package live.narcy.weather.city.controller;
 
+import io.jsonwebtoken.lang.Strings;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -72,14 +73,15 @@ public class CityController {
         if (authentication != null && authentication.getPrincipal() instanceof CustomOAuth2User) {  // Authentication을 통해 추출
             email = ((CustomOAuth2User) authentication.getPrincipal()).getEmail();
 
-            // 조회수 증가
-            viewService.increaseViewCount(email, city, false);
+            // 조회수 증가(회원)
+            viewService.recordViewHistory(email, city);
         } else {
             // 쿠키 검증 및 전처리
             Boolean cookieCheck = checkCookie(request, response, city);
-
-            // 조회수 증가
-            viewService.increaseViewCount(email, city, cookieCheck);
+            if (!cookieCheck && !Strings.hasText(email)) {
+                // 조회수 증가(비회원)
+                viewService.recordViewHistoryAnonymous(city);
+            }
         }
 
         return "contents/cities";
@@ -187,7 +189,7 @@ public class CityController {
                 ));
 
 //                log.info("Date = {}", weatherEntry.getKey());
-                log.info("Date = {}\t최저 온도 = {}\t최고 온도 = {}", weatherEntry.getKey(), minTemp, maxTemp);
+//                log.info("Date = {}\t최저 온도 = {}\t최고 온도 = {}", weatherEntry.getKey(), minTemp, maxTemp);
 
             }
 

--- a/src/main/java/live/narcy/weather/city/service/CityService.java
+++ b/src/main/java/live/narcy/weather/city/service/CityService.java
@@ -103,7 +103,6 @@ public class CityService {
                 InputStream inputStream = thumbnail.getInputStream();
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
         ) {
-
             // 썸네일 생성
             Thumbnails.of(inputStream)
                     .outputQuality(0.95)

--- a/src/main/java/live/narcy/weather/config/RedisConfig.java
+++ b/src/main/java/live/narcy/weather/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package live.narcy.weather.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        // Key: String
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        // Value: String (또는 JSON 직렬화)
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/live/narcy/weather/config/exception/ErrorCode.java
+++ b/src/main/java/live/narcy/weather/config/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     NO_PERMISSION(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
     CITY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 등록된 도시입니다."),
     MISMATCH_ID(HttpStatus.BAD_REQUEST, "ID 불일치"),
+    FAIL_JSON_PARSING(HttpStatus.BAD_REQUEST, "JSON 파싱 실패"),
     FAIL_CREATE_CITY(HttpStatus.BAD_REQUEST, "도시 등록/수정에 실패하였습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/live/narcy/weather/member/entity/Member.java
+++ b/src/main/java/live/narcy/weather/member/entity/Member.java
@@ -21,7 +21,7 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @Column(unique = true)
+    @Column(unique = true)
     private String email;
     private String password;
 

--- a/src/main/java/live/narcy/weather/views/dto/ViewsDto.java
+++ b/src/main/java/live/narcy/weather/views/dto/ViewsDto.java
@@ -2,10 +2,14 @@ package live.narcy.weather.views.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
+@NoArgsConstructor
 public class ViewsDto {
     private Long cityId;
     private Long memberId;

--- a/src/main/java/live/narcy/weather/views/entity/Views.java
+++ b/src/main/java/live/narcy/weather/views/entity/Views.java
@@ -1,6 +1,8 @@
 package live.narcy.weather.views.entity;
 
 import jakarta.persistence.*;
+import live.narcy.weather.city.dto.AreaDto;
+import live.narcy.weather.city.entity.Area;
 import live.narcy.weather.city.entity.City;
 import live.narcy.weather.member.entity.Member;
 import lombok.AccessLevel;
@@ -39,5 +41,12 @@ public class Views {
     public Views(live.narcy.weather.city.entity.City city, Member member) {
         this.city = city;
         this.member = member;
+    }
+
+    public static Views from(City city, Member member) {
+        return Views.builder()
+                .city(city)
+                .member(member)
+                .build();
     }
 }

--- a/src/main/java/live/narcy/weather/views/scheduler/ViewScheduler.java
+++ b/src/main/java/live/narcy/weather/views/scheduler/ViewScheduler.java
@@ -1,0 +1,80 @@
+package live.narcy.weather.views.scheduler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import live.narcy.weather.config.exception.CustomException;
+import live.narcy.weather.config.exception.ErrorCode;
+import live.narcy.weather.views.dto.ViewsDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ViewScheduler {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+
+    // 조회 정보 Redis Key
+    private static final String VIEW_HISTORY_QUEUE_KEY = "view:history:queue";
+    // 한 번에 처리할 배치 사이즈view:history:queue
+    private static final int BATCH_SIZE = 100;
+
+    // 180초(3분) 마다 Flush
+    @Scheduled(fixedDelay = 180000)
+    public void flushViewHistory() {
+
+        // Redis List에서 데이터를 BATCH_SIZE만큼 오른쪽에서 꺼냄
+        // Pop이 동시성 이슈가 적음
+        // rightPop(key, count)는 레디스 서버 6.2 이상부터 지원
+        List<Object> viewJsonList = redisTemplate.opsForList().rightPop(VIEW_HISTORY_QUEUE_KEY, BATCH_SIZE);
+        if (viewJsonList == null || viewJsonList.isEmpty()) {
+            return;
+        }
+
+        List<ViewsDto> viewsDtos = viewJsonList.stream()
+                .map(val -> {
+                    try {
+                        return objectMapper.readValue((String)val, ViewsDto.class); // JSON to DTO
+                    } catch (JsonProcessingException e) {
+                        log.error(String.valueOf(e));
+                        throw new CustomException(ErrorCode.FAIL_JSON_PARSING);
+                    }
+                })
+                .toList();
+
+        String sql = "INSERT INTO views(city_id, member_id, viewed_at) VALUES(?, ?, ?)";
+
+        // JPA saveAll: 엔티티를 1차 캐시에 넣고, 스냅샷을 만들고, 상태를 추적하여 느림 && 내부적으로 insert를 반복하여 N번 DB접근
+        // batchUpdate: 상태 관리가 필요X, SQL을 직접 제어O, 대용량 데이터를 고성능으로 벌크 처리 -> 1번 DB접근
+        jdbcTemplate.batchUpdate(sql,
+                viewsDtos,
+                BATCH_SIZE,
+                (PreparedStatement ps, ViewsDto dto) -> {
+                    ps.setLong(1, dto.getCityId());
+                    // 비회원 조회 정보 일 때
+                    if (dto.getMemberId() == null) {
+                        ps.setNull(2, java.sql.Types.BIGINT);
+                    } else {
+                        ps.setLong(2, dto.getMemberId());
+                    }
+                    ps.setTimestamp(3, Timestamp.valueOf(dto.getViewedAt()));
+        });
+
+        log.info("Redis Flushed-조회 정보 {}건 DB반영", viewsDtos.size());
+    }
+
+}

--- a/src/main/java/live/narcy/weather/views/service/ViewService.java
+++ b/src/main/java/live/narcy/weather/views/service/ViewService.java
@@ -1,6 +1,9 @@
 package live.narcy.weather.views.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import live.narcy.weather.views.dto.MonthlyViewCount;
+import live.narcy.weather.views.dto.ViewsDto;
 import live.narcy.weather.views.dto.YearlyCountryViewRatio;
 import live.narcy.weather.city.entity.City;
 import live.narcy.weather.member.entity.Member;
@@ -10,10 +13,12 @@ import live.narcy.weather.member.repository.MemberRepository;
 import live.narcy.weather.views.repository.ViewRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -27,6 +32,75 @@ public class ViewService {
 
     private final ViewRepository viewRepository;
     private final MemberRepository memberRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    // 조회 정보 Redis Key
+    private static final String VIEW_HISTORY_QUEUE_KEY = "view:history:queue";
+    // 중복 방지용 키 Prefix
+    private static final String VIEW_PREVENT_KEY_PREFIX = "view:prevent:";
+    // 중복 방지 시간(5분)
+    private static final long PREVENT_DURATION_MINUTES = 5;
+
+    /**
+     * 조회수 등록(회원)
+     * @param email
+     * @param city
+     */
+    public void recordViewHistory(String email, City city) {
+        // 사용자 조회
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
+        optionalMember.ifPresent(member -> {
+            long memberId = member.getId();
+            long cityId = city.getId();
+
+            ViewsDto view = ViewsDto.builder()
+                    .memberId(memberId)
+                    .cityId(cityId)
+                    .viewedAt(LocalDateTime.now()).build();
+
+            try {
+                // 중복 방지 키 생성(ex view:prevent:10:3)
+                String preventKey = VIEW_PREVENT_KEY_PREFIX + cityId + ":" + memberId;
+
+                // 중복 여부 체크 후 세팅(SETNX 명령어)
+                // setIfAbsent(SET key value NX EX seconds): 키가 없을 때만 true반환, 있으면 false
+                Boolean isFirstView = redisTemplate.opsForValue()
+                        .setIfAbsent(preventKey, "1", Duration.ofMinutes(PREVENT_DURATION_MINUTES));
+
+                if (Boolean.TRUE.equals(isFirstView)) {
+                    // DTO -> JSON
+                    String viewJson = objectMapper.writeValueAsString(view);
+                    // Redis List의 왼쪽에 데이터 PUSH (큐에 넣기)
+                    redisTemplate.opsForList().leftPush(VIEW_HISTORY_QUEUE_KEY, viewJson);
+                }
+            } catch (Exception e) {
+                log.error("Redis 큐 조회수 등록 중 에러 발생: {}", e.getMessage());
+            }
+        });
+
+    }
+
+    /**
+     * 조회수 등록(비회원)
+     * @param city
+     */
+    public void recordViewHistoryAnonymous(City city) {
+        Long cityId = city.getId();
+        ViewsDto view = ViewsDto.builder()
+                .memberId(null)
+                .cityId(cityId)
+                .viewedAt(LocalDateTime.now()).build();
+
+        try {
+            // DTO -> JSON
+            String viewJson = objectMapper.writeValueAsString(view);
+            // Redis List의 왼쪽에 데이터 PUSH (큐에 넣기)
+            redisTemplate.opsForList().leftPush(VIEW_HISTORY_QUEUE_KEY, viewJson);
+        } catch (Exception e) {
+            log.error("Redis 큐 조회수 등록 중 에러 발생: {}", e.getMessage());
+        }
+    }
 
     /**
      * 조회수 증가(DB저장)


### PR DESCRIPTION
변경 전: @Async를 이용한 비동기 조회 정보 등록 -> 사용자가 증가할 수록 DB접근 증가(부하 발생)

변경 후: Redis 캐시를 이용한 Write-Back 전략으로 조회 정보를 모아서 JdbcTemplate batchUpdate로 한번에 DB Inert처리